### PR TITLE
Public ingredients

### DIFF
--- a/src/components/home/filters/HomeFilters.module.css
+++ b/src/components/home/filters/HomeFilters.module.css
@@ -206,3 +206,23 @@
         justify-content: flex-end;
     }
 }
+
+@media (min-width: 820px) {
+    .filterBar {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    .filterBar__categories {
+        justify-content: space-between;
+        font-size: inherit;
+    }
+
+    .filterBar__categoryType {
+        flex-basis: 27%;
+    }
+
+    .searchBarContainer {
+        margin-bottom: 0;
+    }
+}

--- a/src/dataManagers/categoryManager.ts
+++ b/src/dataManagers/categoryManager.ts
@@ -2,7 +2,7 @@ import { Category, CategoryType } from "@/types/categoryType"
 
 const apiUrl: string = 'http://localhost:8000'
 
-
+/**Retrieves all public categories */
 export const getCategories = async (): Promise<Category[]> => {
     const res = await fetch(`${apiUrl}/categories`, {cache: "force-cache"})
     if (!res.ok) {

--- a/src/dataManagers/recipeManagers/recipeManager.ts
+++ b/src/dataManagers/recipeManagers/recipeManager.ts
@@ -34,7 +34,7 @@ export const getRecipes = async (queryParams: string): Promise<Recipe[]> => {
       method: "GET",
       headers: reqHeaders,
       cache: "force-cache",
-      next: { tags: ['recipes'] }
+      next: { tags: ['recipes'], revalidate: 30 }
     })
     if (!res.ok) {
         throw Error("Unable to fetch Recipes") 

--- a/src/types/categoryType.ts
+++ b/src/types/categoryType.ts
@@ -2,7 +2,9 @@ export type Category = {
     id: number,
     name: string,
     category_type: number,
-    category_type_label: string
+    category_type_label: string,
+    public: boolean,
+    created_by: number
 }
 
 export type CategoryType = {

--- a/src/types/ingredientType.ts
+++ b/src/types/ingredientType.ts
@@ -9,5 +9,7 @@ export type AttachedIngredient = {
 
 export type Ingredient = {
     id: number,
-    name: string
+    name: string,
+    public: boolean,
+    created_by: number
 }


### PR DESCRIPTION
## Changes Made
- Updated getIngredients function to use the `/ingredients/custom_list` endpoint. This will fetch ingredients that are marked `public: true` as well as ingredients that were created by the authenticated user making the request. If no authentication credentials provided, the function redirects to `/login`. The purpose of this is so that users can only interact with their own custom ingredients by default, since newly created ingredients will have the `public` property set to `false`. If an admin changes the status of the custom ingredient to `public: true`, then it will be available to any user, authenticated or not.
- Updated Category type definition
- Added interval to revalidate recipe feed.

Resolves #37 